### PR TITLE
Feature/add thinking support

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -42,6 +42,7 @@ export class ChatApplication {
 			try {
 				await this.ollamaService.sendMessage(input);
 				this.cliUtils.newLine();
+				console.log(this.ollamaService.getContext());
 			} catch (err) {
 				this.cliUtils.log('Error processing message.', err.message);
 			}

--- a/src/app.js
+++ b/src/app.js
@@ -42,7 +42,6 @@ export class ChatApplication {
 			try {
 				await this.ollamaService.sendMessage(input);
 				this.cliUtils.newLine();
-				console.log(this.ollamaService.getContext());
 			} catch (err) {
 				this.cliUtils.log('Error processing message.', err.message);
 			}

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,8 +1,8 @@
 export const CONFIG = {
 	OLLAMA: {
 		STREAM: true,
-		MODEL: 'gemma3:1b',
-		THINK: false,
+		MODEL: 'deepseek-r1:1.5b',
+		THINK: true,
 	},
 	EXIT_COMMANDS: ['sair', 'exit', 'quit'],
 	PROMPTS: {


### PR DESCRIPTION
This pull request introduces enhancements to the `OllamaService` and its associated configuration, improves the handling of the `THINK` parameter for better user feedback during message processing, and updates the test suite to reflect these changes. Key updates include the addition of a "thinking" phase in the response flow, changes to the configuration constants, and improved test coverage.

### Enhancements to `OllamaService`:

* Added a "thinking" phase to the response flow when `CONFIG.OLLAMA.THINK` is enabled. This displays a "Thinking" message before the assistant's response and ensures a clear separation between the two phases.

### Updates to configuration:

* Updated `CONFIG.OLLAMA.MODEL` to use a new model (`deepseek-r1:1.5b`) and enabled the `THINK` parameter by default in `src/config/constants.js`.

### Improvements to testing:

* Added mock implementations for `CONFIG` and the `ollama` module to isolate tests from external dependencies in `tests/services/ollama.service.test.js`.
* Introduced new test cases to validate access to `CONFIG.OLLAMA` parameters (`THINK`, `STREAM`, and `MODEL`) and ensure correct behavior of the updated `OllamaService`.

### Minor logging addition:

* Added a debug log to display the current message context in `ChatApplication` for better traceability during message processing.